### PR TITLE
changed to set style without using stylesheet, added reset

### DIFF
--- a/manipulateCSS-Classes/changeBackgroundColor/code.js
+++ b/manipulateCSS-Classes/changeBackgroundColor/code.js
@@ -1,8 +1,38 @@
-function changeColor(){
+// default values taken from chameleon class
+const defaultColor = 'black';
+const defaultBgColor = 'lightgrey';
 
-    var selectedColor = document.getElementById('color-selector').value;
-    document.styleSheets[0].cssRules[0].style.color=selectedColor;
+function changeColor() {
+    // get chosen values for color and bg-color
+    const selectedColor = document.getElementById('color-selector').value;
+    const selectedBgColor = document.getElementById('bg-color-selector').value;
 
+    // get all elements with the chameleon class applied
+    // getElementsByClassName returns HTMLCollectionOf<Element> so we use Array.from
+    // to convert it to an array, so we can use array methods on the const chameleonElements
+    const chameleonElements = Array.from(document.getElementsByClassName('chameleon'));
+
+    // change the color and bg-color of the elements
+    //
+    // we use bracket notation here to access the properties "color" and "background-color"
+    // because we would not be able to access element.style.background-color => the dash in
+    // "background-color" prevents us from accessing it this way. Javascript interprets this
+    // as a subtraction: "element.style.background - color" and this does not work.
+    //
+    // To learn more about bracket notation and other ways to access object properties, read
+    // more about it here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_with_Objects
+    chameleonElements.forEach(element => {
+        element.style["color"] = selectedColor;
+        element.style["background-color"] = selectedBgColor;
+    });
+}
+
+function reset() {
+    const chameleonElements = Array.from(document.getElementsByClassName('chameleon'));
+    chameleonElements.forEach(element => {
+        element.style["color"] = defaultColor;
+        element.style["background-color"] = defaultBgColor;
+    });
 }
 
 

--- a/manipulateCSS-Classes/changeBackgroundColor/index.html
+++ b/manipulateCSS-Classes/changeBackgroundColor/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>change class rules color and backgroundcolor</title>
-    <link rel="stylesheet" href="./style.css">
+    <link rel="stylesheet" href="style.css">
     <script src="code.js"></script>
 </head>
 <body>
@@ -19,7 +19,16 @@
         <option value="darkkhaki">nice darkkhaki</option>
     </select>
     <br>
+    <label for="bg-color">choose your background-color</label>
+    <select name="bg-color" id="bg-color-selector">
+        <option value="green">nice green bg</option>
+        <option value="red">nice red bg</option>
+        <option value="blue">nice blue bg</option>
+        <option value="darkkhaki">nice darkkhaki bg</option>
+    </select>
+    <br>
     <button onclick="changeColor()">change the color of all chameleon class elements</button>
+    <button onclick="reset()">reset to default</button>
     <h2 class="chameleon">i am a h2 element with the class of chameleon</h1>
     <h2 class="chameleon">so am i</h1>
     <div class="chameleon">hi i am a div and i also belong to the chameleon class</div>

--- a/manipulateCSS-Classes/changeBackgroundColor/style.css
+++ b/manipulateCSS-Classes/changeBackgroundColor/style.css
@@ -1,9 +1,5 @@
-
-.chameleon{
+.chameleon {
     font-size: 50px;
     color: black;
     background-color: lightgrey;
-
 }
-
-


### PR DESCRIPTION
#2 help on css class rule manipulation

I implemented a version that is able to set and reset color and background color individually. The approach with the direct stylesheet manipulation is not recommended because it can cause security issues and access to the stylesheet will be blocked by the browser (e.g.: did not work in chrome when i tested it).

This approach changes the color and background-color style properties of the elements directly.


===
Another way to do it would be to create different classes for every color you provide in the select and then just change the class that is applied to the element.

Classes would then look something like this:

```
.bg-default {
    background-color: lightgrey;
}

.bg-blue {
    background-color: blue;
}

.bg-green {
    background-color: green;
}

...
```

Then you could simply remove and set classes for the elements like this:

```
element.classList.remove("bg-default");
element.classList.add("bg-blue");
```